### PR TITLE
Set socket timeout to 5 minutes

### DIFF
--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -321,7 +321,9 @@ def _execute_gql_query(
             context = None
             if allow_insecure_https:
                 context = ssl.SSLContext()
-            connection_timeout_in_seconds = 10
+            # Set an upper-bound to prevent process hangs on network issues, otherwise clients can
+            # hang indefinitely in certain network conditions:
+            connection_timeout_in_seconds = 300
             # NB: Mark urlopen() call with 'nosec' to acknowledge handling file:/ condition:
             LOGGER.debug("Calling urllib.request.urlopen(...)")
             response = urllib.request.urlopen(

--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -43,8 +43,9 @@ Queries with variables are also supported by "wrapping" your query like so:
 # 0.5.0  20200825: Updates for splitting jebena_cli.py into a stand-alone package. -JP
 # 0.6.0  20201030: Various small fixes, including multi-line support of wrapped queries. -JP
 # 0.7.0  20201221: Address issues as flagged in GH (don't retry mutations; better error handling). -JP
+# 0.7.1  20210128: Address socket timeout issue. -JP
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"
 
 import http.client
 import json


### PR DESCRIPTION
Fixes #5 -- we want _some_ max upper bound on API communication; the 10 second logic we had turns out to apply to the entire lifecycle of urllib calls, not just the open. See issue for details.