### PR TITLE
Add support for operation_name optional arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,4 @@ test:
 	@# in both Python 2.7 and 3.x.
 	echo 'query { me { person { displayName } } }' | python2.7 -m jebenaclient
 	echo 'query { me { person { displayName } } }' | python3 -m jebenaclient
+	echo '{ "query": "query getDisplayName { me { person { displayName } } }",  "variables": {"foo": "bar"},  "operationName": "getDisplayName" }' | python3 -m jebenaclient

--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -57,7 +57,8 @@ Queries with variables are also supported by "wrapping" your query like so:
 # 0.7.1  20210128: Address socket timeout issue.
 # 0.8.0  20210204: Make script Python 2.7 compatible.
 # 0.8.1  20210217: Handle some flake8 / mypy issues in a Py 2.7 compatible way.
-__version__ = "0.8.1"
+# 0.8.2  20210302: Add support for GQL "operationName" parameter
+__version__ = "0.8.2"
 
 import http.client
 import json

--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -40,6 +40,13 @@ Queries with variables are also supported by "wrapping" your query like so:
     "variables": {"foo": "bar"}
 }
 
+Or, with an operation name:
+{
+    "query": "query operationName { me { person { displayName } } }",
+    "variables": {"foo": "bar"},
+    "operationName": "getDisplayName"
+}
+
 """
 
 # Version history:


### PR DESCRIPTION
Our client did not implement the optional `operationName` field for GQL.

This PR adds support for this field in either direct python usage or wrapped queries. We've kept our current client bare-bones, including no command line flags, so I've not added any command line flag for this.