### PR TITLE
Fix httplib import for Py 2.7

### DIFF
--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -65,9 +65,9 @@ Or, with an operation name:
 # 0.8.0  20210204: Make script Python 2.7 compatible.
 # 0.8.1  20210217: Handle some flake8 / mypy issues in a Py 2.7 compatible way.
 # 0.8.2  20210302: Add support for GQL "operationName" parameter
-__version__ = "0.8.2"
+# 0.8.3  20210316: Fix for http.lib import
+__version__ = "0.8.3"
 
-import http.client
 import json
 import logging
 import os
@@ -80,15 +80,19 @@ from threading import Timer
 
 # Python 2 compatibility:
 try:
+    from http.client import RemoteDisconnected
+except ImportError:
+    from httplib import BadStatusLine as RemoteDisconnected  # Py 2
+try:
     from urllib.parse import urlparse
 except ImportError:
-    from urlparse import urlparse
+    from urlparse import urlparse  # Py 2
 try:
     import urllib.request as urllib_request
     from urllib.request import urlopen
 except ImportError:
-    import urllib2 as urllib_request
-    from urllib2 import urlopen
+    import urllib2 as urllib_request  # Py 2
+    from urllib2 import urlopen  # Py 2
 
 LOGGER = logging.getLogger("jebenaclient")
 
@@ -475,7 +479,7 @@ def _execute_gql_query(
             )
             continue
 
-        except http.client.RemoteDisconnected as exc:
+        except RemoteDisconnected as exc:
             _log_and_raise_or_retry(
                 "Remote Disconnected Exception (%s)",
                 str(exc)


### PR DESCRIPTION
## Background

As previously discussed, we want our client to work in as many cases as possible, including Python 2.7. The `http.client` package doesn't formally exist in Python 2.7, although interestingly a number of vendor distros support it:

MacOS works:
```
Python 2.7.16 (default, Jun  5 2020, 22:59:21) 
[GCC 4.2.1 Compatible Apple LLVM 11.0.3 (clang-1103.0.29.20) (-macos10.15-objc- on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import http.client
>>> 
```

Ubuntu 16 works:
```
Python 2.7.12 (default, Mar  1 2021, 11:38:31) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import http.client
>>> 
```

But: AWS Linux fails:
```
Python 2.7.18 (default, Feb 18 2021, 06:07:59) 
[GCC 7.3.1 20180712 (Red Hat 7.3.1-12)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import http.client
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: No module named http.client
>>> 
```

## Solution:

Simple fix: try/catch around the appropriate import.