### PR TITLE
Call logging.basicConfig in Python2 setups

### DIFF
--- a/jebenaclient/jebenaclient.py
+++ b/jebenaclient/jebenaclient.py
@@ -67,7 +67,8 @@ Or, with an operation name:
 # 0.8.2  20210302: Add support for GQL "operationName" parameter
 # 0.8.5  20210316: More fixes for Python 2.7
 # 0.8.6  20210318: Expose retry logic for mutations for developers
-__version__ = "0.8.6"
+# 0.8.7  20210517: Fix for spurious warning in Python2 setups for logging
+__version__ = "0.8.7"
 
 import json
 import logging
@@ -105,7 +106,8 @@ except ImportError:
     from urllib2 import urlopen  # Py 2
 
 LOGGER = logging.getLogger("jebenaclient")
-
+if sys.version_info[0] == 2:
+    logging.basicConfig()
 
 class JebenaCliException(Exception):
     """Generic client error, indicating an issue with the connection or setup."""


### PR DESCRIPTION
Fixes #16 

In Python 3, calling logger.warn/error/whatever() functions automatically triggers logging configuration when it's not been set up. In Python 2, not configuring logging causes a spurious `No handlers could be found for logger "jebenaclient"` to be emitted.

This PR only calls basicConfig() when in python2 -- from what I recall, calling basicConfig() in a package that one imports can cause some side-effects if the main program hasn't already triggered its logging config. (Essentially: the first call to configure logging is the one that wins; or at least by default. I would need to research to confirm if this is strictly true, but ... I've seen enough issues with this pattern to want to avoid it.)

Simple way to reproduce the issue:

1) In `test.py`, put:
```
import foo
foo.bar()
```

2) In `foo.py`, put:
```
import logging
LOGGER = logging.getLogger("jebenaclient")
# logging.basicConfig()

def bar():
  LOGGER.error("error log")
  print("bar() called, logger stuff called.")
```

Running `python3 test.py` will result in just the print() statement; running python2 will cause the logger-not-configured error. (Note I'm testing on MacOS, where future imports automatically support `print()` notation in Python 2.)