### PR TITLE
Support for Jebena Trace ID; fix for Python2 Logging setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,12 @@ where loading secrets in the ENV is not practical.
    * `api_secret_key`: The secret key associated with your API key name.
     When not passed, ENV variable JEBENA_API_SECRET_KEY is read. This value must
     be kept securely stored!
+
+
+### Working with Jebena Trace IDs
+
+The Jebena API Server provides a "Jebena Trace ID" that can be used for tracing
+the backend server's logs for any given request. This is provided as an HTTP header to clients.
+
+Calling `jebenaclient.get_last_run_trace_id()` after any call to `jebenaclient.run_query()` will provide the Jebena Trace ID,
+which can then be used by server developers (e.g. `jebena aws logs trace <id>`)

--- a/jebenaclient/__init__.py
+++ b/jebenaclient/__init__.py
@@ -11,8 +11,10 @@ from .jebenaclient import (  # noqa: F401
     JebenaCliGQLPermissionDenied,
     JebenaCliMissingKeyException,
     run_query,
+    get_last_run_trace_id,
 )
 
 __all__ = [
     'run_query',
+    'get_last_run_trace_id',
 ]


### PR DESCRIPTION
This fixes #16 (for a second time) and addresses #18.

# Python Logging

The issue appears to be related to python2 envs that already have logging configured. After some investigation, the cleanest way I can find to check this condition is to see if the root logger has any handlers attached to it (i.e. stream writers or file writers). If no handlers; logging not configured.

This PR updates the client to call a function, `__get_logger`, that can lazy-load the logger and configure it accordingly. This allows the `jebenaclient` to be imported _before_ other parts of the python system may have triggered their logging config.

# Jebena Trace ID

Developers wanting to fetch the Jebena Trace ID of the most recent call to `run_query()` can now do so by calling `jebenaclient.get_last_run_trace_id()` -- simple enough. This should work after a failed GQL call as well, i.e. calling something like this:

```python
import jebenaclient
try:
   jebenaclient.run_query("some bad query")
except jebenaclient.JebenaCliGQLException:
   print("Failed to run query for trace id %s" % jebenaclient.get_last_run_trace_id())
```

yields this -- note the very last line.
```
ERROR:jebenaclient:GQL response includes an error. Part of the query may have succeeded.
 *** The original query was:
'some bad query'

 *** The full response was:
{   u'data': None,
    u'errors': [   {   u'locations': [{   u'column': 1, u'line': 1}],
                       u'message': u'Syntax Error GraphQL (1:1) Unexpected Name "some"\n\n1: some bad query\n   ^\n'}]}


ERROR:jebenaclient: *** GQL error #1: Syntax Error GraphQL (1:1) Unexpected Name "some"

1: some bad query
   ^

ERROR:jebenaclient:For GraphQL schema, see Docs tab at https://staging.api.enveritas.net/v1/docs/graphiql
Failed to run query for trace id J-2ddadfe8-4732-01750
```